### PR TITLE
Fix NullPointerException when calling getBBox

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
@@ -127,13 +127,13 @@ class RNSVGRenderableManager extends ReactContextBaseJavaModule {
         svg.initBounds();
 
         RectF bounds = new RectF();
-        if (fill) {
+        if (fill && svg.mFillBounds != null) {
             bounds.union(svg.mFillBounds);
         }
-        if (stroke) {
+        if (stroke && svg.mStrokeBounds != null) {
             bounds.union(svg.mStrokeBounds);
         }
-        if (markers) {
+        if (markers && svg.mMarkerBounds != null) {
             bounds.union(svg.mMarkerBounds);
         }
         if (clipped) {


### PR DESCRIPTION
When calling `getBBox()` inside an `onLayout` callback of a `<Rect />`, we were getting a exception thrown:
NullPointerException: Attempt to read from field 'float android.graphics.RectF.left' on a null object reference.